### PR TITLE
Rename repository from Back-Projection to the Stanford Radar Group SAR Processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0]
+### Changed
+- Rename repository from Back-Projection to the Stanford Radar Group SAR Processor (SRG)
+
 ## [0.3.1]
 ### Fixed
 - Double-slash in call to `sentinel_raw_process_cpu`.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
-# Back Projection
+# Stanford Radar Group (SRG) SAR Processor
 
-This repository hosts the workflow for the deformation time series of volcanic regions from space-geodetic InSAR and GNSS observations project, which aims to provide crustal deformation data for every active volcano in the world. 
-Workflows in this repository combine time series SBAS InSAR analyses using Sentinel-1 and NISAR data and the Stanford InSAR processor with GNSS measurement data.
-
+This repository hosts the Stanford Radar Group (SRG) SAR Processor, which includes utilities for performing the deformation time series analysis of volcanic regions from space-geodetic InSAR and GNSS observations. The SRG processor is being used within the NASA-funded XXX (LAVAS) project, which aims to provide crustal deformation data for every active volcano in the world. 
 
 THIS IS RESEARCH CODE PROVIDED TO YOU "AS IS" WITH NO WARRANTIES OF CORRECTNESS. USE AT YOUR OWN RISK.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Stanford Radar Group (SRG) SAR Processor
 
-This repository hosts the Stanford Radar Group (SRG) SAR Processor, which includes utilities for performing the deformation time series analysis of volcanic regions from space-geodetic InSAR and GNSS observations. The SRG processor is being used within the NASA-funded XXX (LAVAS) project, which aims to provide crustal deformation data for every active volcano in the world. 
+This repository hosts the Stanford Radar Group (SRG) SAR Processor, which includes utilities for performing the deformation time series analysis of volcanic regions from space-geodetic InSAR and GNSS observations. The SRG processor is being used within the NASA-funded Live Analysis of Volcano Activity (LAVAS) project, which aims to provide crustal deformation data for every active volcano in the world. 
 
 THIS IS RESEARCH CODE PROVIDED TO YOU "AS IS" WITH NO WARRANTIES OF CORRECTNESS. USE AT YOUR OWN RISK.


### PR DESCRIPTION
Back-projection is really just the name of the core method that the SRG uses. It's more appropriate to call the repository SRG since this is the name of the overall processor (a la ISCE2 or GAMMA).